### PR TITLE
Fix long/float encoders.

### DIFF
--- a/lib/lame/buffer.rb
+++ b/lib/lame/buffer.rb
@@ -3,7 +3,7 @@ module LAME
 
     def self.create(type, input)
       buffer = ::FFI::MemoryPointer.new(type, input.size)
-      buffer.put_array_of_short(0, input)
+      buffer.send(:"put_array_of_#{type}", 0, input)
       buffer
     end
 

--- a/lib/lame/encoding/long_buffer_encoder.rb
+++ b/lib/lame/encoding/long_buffer_encoder.rb
@@ -3,7 +3,7 @@ module LAME
     class LongBufferEncoder < StereoBufferEncoder
 
       def data_type
-        :long
+        :"int#{::LAME::FFI::LONG_SIZE}"
       end
 
       def lame_function

--- a/lib/lame/encoding/stereo_buffer_encoder.rb
+++ b/lib/lame/encoding/stereo_buffer_encoder.rb
@@ -14,6 +14,7 @@ module LAME
       def encode_frame(left, right)
         left_buffer  = Buffer.create(data_type, left)
         right_buffer = Buffer.create(data_type, right)
+
         output       = Buffer.create_empty(:uchar, output_buffer_size)
 
         mp3_size = LAME.send(lame_function, global_flags,

--- a/lib/lame/ffi.rb
+++ b/lib/lame/ffi.rb
@@ -9,6 +9,8 @@ require 'lame/ffi/mp3_data'
 module LAME
   module FFI
 
+    LONG_SIZE = ::FFI.type_size(:long) * 8
+
     def self.included(base)
       base.class_eval do
         include Enums

--- a/spec/encoding/stereo_buffer_encoder_spec.rb
+++ b/spec/encoding/stereo_buffer_encoder_spec.rb
@@ -85,7 +85,8 @@ module LAME
 
     describe LongBufferEncoder do
       it_should_behave_like "a stereo buffer encoder" do
-        let(:data_type) { :long }
+        # can be either int32 or int64 depending on system architecture
+        let(:data_type) { :"int#{::LAME::FFI::LONG_SIZE}" }
         let(:lame_function) { :lame_encode_buffer_long2 }
       end
     end


### PR DESCRIPTION
Using `encoder.encode_long`, `encoder.encode_float` and `encoder.encode_interleaved_float` do not work because `Buffer.create` always uses the `put_array_of_short` function instead of the proper types.

This PR fixes that.

Also included are integration tests of 24-bit WAV files for `encode_long` and `encode_float`.
